### PR TITLE
BUGFIX: Force JSON objects and for empty array

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -152,9 +152,9 @@ class Client
 	*
 	* @return RequestInterface
 	*/
-	private function createRequest($method, $uri, array $options = [], $body = '')
+	private function createRequest($method, $uri, array $options = [], $body = '{}')
 	{
-		$ret = new Request($method, $uri, $options, is_array($body) ? json_encode($body) : $body);
+		$ret = new Request($method, $uri, $options, is_array($body) ? json_encode($body, JSON_FORCE_OBJECT) : $body);
 
 		if (isset($options['query'])) {
 			$uri = $ret->getUri()->withQuery(is_array($options['query']) ? http_build_query($options['query']) : $options['query']);


### PR DESCRIPTION
- Empty array is now forced to generate an empty JSON object i.e {}
- Empty string now represents an empty JSON object i.e {}
- See https://stackoverflow.com/questions/41150119/bad-request-error-on-surveymonkey-v3-send