### PR TITLE
Guzzle throwing exception when no filters are passed, there are no valid filters for request to pass...

### DIFF
--- a/src/Api/ResponsesTrait.php
+++ b/src/Api/ResponsesTrait.php
@@ -169,25 +169,21 @@ trait ResponsesTrait
 	/**
 	* getSurveyResponse
 	*
-	* @param int $collectorId
+	* @param int $surveyId
 	* @param int $responseId
 	* @param bool $detailed
 	*
 	* @return @see Client::sendRequest
 	*/
-	public function getSurveyResponse($surveyId, $responseId, $detailed = false, array $filters = [])
+	public function getSurveyResponse($surveyId, $responseId, $detailed = false)
 	{
 		if ($detailed) {
 			return $this->sendRequest(
-				$this->createRequest('GET', sprintf('surveys/%s/responses/%s/details', $surveyId, $responseId), [ 
-					'query' => $filters 
-				])
+				$this->createRequest('GET', sprintf('surveys/%s/responses/%s/details', $surveyId, $responseId))
 			);
 		} else {
 			return $this->sendRequest(
-				$this->createRequest('GET', sprintf('surveys/%s/responses/%s', $surveyId, $responseId), [ 
-					'query' => $filters 
-				])
+				$this->createRequest('GET', sprintf('surveys/%s/responses/%s', $surveyId, $responseId))
 			);
 		}
 	}


### PR DESCRIPTION
So the ResponseTrait::getSurveyResponse method has a "filter parameter" but the API docs explain that there is no filter options for this call. Its a basic GET call where the only parameters are in the URL. Leaving the parameter for $filter blank as the API suggests, causes the headers variable to contain a property for "query" that is set to an empty array which causes a `Guzzle\InvalidArgumentException` to be thrown.

I have removed the $filter parameter from the trait method signature and omitted the the code from being passed down stream which results in a working fix.  I have not checked the other methods here but I think this issue may effect other methods. I would recommend retesting them.