### PR TITLE
Survey Monkey request without json body

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -159,7 +159,7 @@ class Client
         $ret = new Request($method, $uri, []);
 
         if (is_array($body)) {
-            $bodyString = json_encode($body);
+            $ret = new Request($method, $uri, [], json_encode($body));
         }
 
         if (isset($options['query'])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -151,15 +151,16 @@ class Client
      */
     private function createRequest($method, $uri, array $options = [], $body = null)
     {
-        if (empty($body)) {
-            // Empty arrays and NULL data inputs both need casting to an empty JSON object.
-            // See https://stackoverflow.com/a/41150809/2803757
-            $bodyString = '{}';
-        } elseif (is_array($body)) {
+
+        /* 
+            Survey Monkey moved to CloudFront on 2020-05-23
+            CloudFront issues 403 Forbidden with empty json body
+        */    
+        $ret = new Request($method, $uri, []);
+
+        if (is_array($body)) {
             $bodyString = json_encode($body);
         }
-
-        $ret = new Request($method, $uri, [], $bodyString);
 
         if (isset($options['query'])) {
             $uri = $ret->getUri()->withQuery(is_array($options['query']) ? http_build_query($options['query']) : $options['query']);


### PR DESCRIPTION
Survey Monkey moved to CloudFront on 2020-05-23.   CloudFront issues 403 Forbidden with empty json body. Removed body from request.

I'm kinda new at this so please provide feedback if I screwed up.