### PR TITLE
BUGFIX: copyCollectorMessage returning 1001 error

### DIFF
--- a/src/Api/CollectorsTrait.php
+++ b/src/Api/CollectorsTrait.php
@@ -172,12 +172,10 @@ trait CollectorsTrait
 	public function copyCollectorMessage($collectorId, $fromCollectorId, $fromMessageId, $includeRecipients = false)
 	{
 		return $this->sendRequest(
-			$this->createRequest('POST', sprintf('collectors/%s/messages', $collectorId), [
-				'query' => [
-					'from_collector_id'  => $fromCollectorId,
-					'from_message_id' 	 => $fromMessageId,
-					'include_recipients' => (bool)$includeRecipients,
-				]
+			$this->createRequest('POST', sprintf('collectors/%s/messages', $collectorId), [], [
+                		'from_collector_id'  => (string)$fromCollectorId,
+                		'from_message_id'    => (string)$fromMessageId,
+                		'include_recipients' => (bool)$includeRecipients,
 			])
 		);
 	}


### PR DESCRIPTION
Function currently returns 1001, changes made;

* Data now set
* Data forces to string, if ID is set as INT 1002 error returned