### PR TITLE
BUGFIX: sendCollectorMessage returning 1002 when no data

### DIFF
--- a/src/Api/CollectorsTrait.php
+++ b/src/Api/CollectorsTrait.php
@@ -265,7 +265,7 @@ trait CollectorsTrait
 	 */
 	public function sendCollectorMessage($collectorId, $messageId, \DateTime $scheduledDate = null)
 	{
-		$data = $scheduledDate ? [ 'scheduled_date' => $scheduledDate->format(DATE_ATOM) ] : [];
+		$data = $scheduledDate ? [ 'scheduled_date' => $scheduledDate->format(DATE_ATOM) ] : new \stdClass();
 		
 		return $this->sendRequest(
 			$this->createRequest('POST', sprintf('collectors/%s/messages/%s/send', $collectorId, $messageId), [], $data)

--- a/src/Client.php
+++ b/src/Client.php
@@ -156,7 +156,7 @@ class Client
             // CloudFront issues 403 Forbidden with empty json body
             // Previously this was set to an empty json object string. See https://stackoverflow.com/a/41150809/2803757
             $bodyString = null;
-        } elseif (is_array($body)) {
+        } elseif (is_array($body) || $body instanceof \stdClass) {
             $bodyString = json_encode($body);
         }
 


### PR DESCRIPTION
https://developer.surveymonkey.com/api/v3/#collectors-id-messages-id-send

API Documentation says no data is required... however... the API endpoint rejects

no body
null
[]

and requires {} when scheduled_date is not set or it returns a 1002 error. Comments on line 155 to 157 of src/Client.php seem to suggest that {} will throw an error on CloudFront, I'm not seeing that behaviour with this API call.

I've put this workaround in to allow you to create a {} body by using stdClass.