### PR TITLE
Updated guzzle deps to support 6.* OR 7.* for compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.lock
 /authenticator/creds.php
 /.idea/
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ghassani/surveymonkey-v3-api-php",
-    "version" : "1.1.2",
+    "version" : "1.1.3",
     "authors": [
         {
             "name": "Gassan Idriss",

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,14 @@
     "require": {
         "php": ">=5.5",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "6.*@stable"
+        "guzzlehttp/guzzle": "6.*@stable|7.*@stable"
     },
     "autoload" : {
         "psr-4" : {
             "Spliced\\SurveyMonkey\\" : "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -35,7 +35,7 @@ class Authenticator
 	/** @const string */
 	const OAUTH_ENDPOINT = 'https://api.surveymonkey.net/oauth/';
 
-	/** @var GuzzleHttp\Client */
+	/** @var HttpClient */
 	protected $httpClient;
 
 	/** @var string */
@@ -49,8 +49,6 @@ class Authenticator
 
 	/**
 	 * Constructor
-	 *
-	 * @return Client
 	 */
 	public function __construct($clientId, $clientSecret, $redirectUri)
 	{
@@ -70,7 +68,7 @@ class Authenticator
 	 *
 	 * @param string $clientId
 	 *
-	 * @return Client
+	 * @return Authenticator
 	 */
 	public function setClientId($clientId)
 	{
@@ -93,7 +91,7 @@ class Authenticator
 	 *
 	 * @param string $clientSecret
 	 *
-	 * @return Client
+	 * @return Authenticator
 	 */
 	public function setClientSecret($clientSecret)
 	{
@@ -116,7 +114,7 @@ class Authenticator
 	 *
 	 * @param string $redirectUri
 	 *
-	 * @return Client
+	 * @return Authenticator
 	 */
 	public function setRedirectUri($redirectUri)
 	{
@@ -137,7 +135,7 @@ class Authenticator
 	/**
 	 * getHttpClient
 	 *
-	 * @return \GuzzleHttp\Client
+	 * @return HttpClient
 	 */
 	public function getHttpClient()
 	{
@@ -159,13 +157,14 @@ class Authenticator
 		]));
 	}
 
-	/**
-	 * getToken
-	 *
-	 * @param string $code - Code received from redirect from SurveyMonkey after pointing the user to getAuthorizeUrl()
-	 *
-	 * @return array
-	 */
+    /**
+     * getToken
+     *
+     * @param string $code - Code received from redirect from SurveyMonkey after pointing the user to getAuthorizeUrl()
+     *
+     * @return array
+     * @throws SurveyMonkeyApiException
+     */
 	public function getToken($code)
 	{
 		$request = 	new Request('POST', 'token', [], http_build_query([
@@ -178,9 +177,11 @@ class Authenticator
 
 		try {
 			$response = $this->getHttpClient()->send($request);
-		} catch (\Exception $e) {
+		} catch (GuzzleException $e) {
 			throw new SurveyMonkeyApiException($e->getMessage(), $e->getCode(), $e);
-		}
+		} catch (\Exception $e) {
+            throw new SurveyMonkeyApiException($e->getMessage(), $e->getCode(), $e);
+        }
 
         if (!$response->hasHeader('content-type') || !preg_match('/application\/json/i', $response->getHeader('content-type')[0])) {
 			throw new SurveyMonkeyApiException(sprintf('Response expected to be a JSON response. Received %s', $response->getHeader('content-type')[0]));

--- a/src/Client.php
+++ b/src/Client.php
@@ -121,7 +121,7 @@ class Client
     }
 
     /**
-     * @param RequestInterface
+     * @param RequestInterface $request
      * @return Response
      * @throws SurveyMonkeyApiException if we got an error response from SurveyMonkey
      * @throws \GuzzleHttp\Exception\GuzzleException on unexpected HTTP errors

--- a/tests/ContactTest.php
+++ b/tests/ContactTest.php
@@ -35,6 +35,9 @@ class ContactTest extends BaseTest
 
 		$newContactListData = $createContactListResponse->getData();
 
+        $this->assertEmpty($newContactListData['error'], 'API Error: '
+            . $newContactListData['error']['name'] . ': ' . $newContactListData['error']['message'] . '.');
+
 		$this->isType('array', $newContactListData);
 		$this->arrayHasKey('id',  $newContactListData);		
 		$this->arrayHasKey('name',$newContactListData);
@@ -47,6 +50,9 @@ class ContactTest extends BaseTest
 		);
 
 		$updateContactListData = $updateContactListResponse->getData();
+
+        $this->assertEmpty($updateContactListData['error'], 'API Error: '
+            . $updateContactListData['error']['name'] . ': ' . $updateContactListData['error']['message'] . '.');
 
 		$this->isType('array', $updateContactListData);
 		$this->arrayHasKey('id',  $updateContactListData);		
@@ -62,6 +68,9 @@ class ContactTest extends BaseTest
 
 		$replaceContactListData = $replaceContactListResponse->getData();
 
+        $this->assertEmpty($replaceContactListData['error'], 'API Error: '
+            . $replaceContactListData['error']['name'] . ': ' . $replaceContactListData['error']['message'] . '.');
+
 		$this->isType('array', $replaceContactListData);
 		$this->arrayHasKey('id',  $replaceContactListData);		
 		$this->arrayHasKey('name',$replaceContactListData);
@@ -72,6 +81,9 @@ class ContactTest extends BaseTest
 		$deleteContactListResponse = $this->client->deleteContactList($newContactListData['id']);
 		
 		$deleteContactListData = $deleteContactListResponse->getData();
+
+        $this->assertEmpty($deleteContactListData['error'], 'API Error: '
+            . $deleteContactListData['error']['name'] . ': ' . $deleteContactListData['error']['message'] . '.');
 
 		$this->isType('array', $deleteContactListData);
 		$this->arrayHasKey('id',  $deleteContactListData);		


### PR DESCRIPTION
- src/Client.php: Fixed missing parameter name in a phpDocBlock comment.
- src/Authenticator.php: Fixed bad phpDocBlock comments / Added extra catch for GuzzleException since that class does not appear to extend \Exception and \Throwable cannot be used here since we need to support < php7.1
- Updated ContactTest.php to assert an error value is not returned on all API calls and to spit out the error message returned to the command line in the event of a failed test.
- Update the composer.json deps to support guzzle 6 and/or guzzle 7, also added dev requirement for phpunit.
- Added .phpunit.result.cache file to .gitignore